### PR TITLE
updated outfile to reference correct variable for source_version_file

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -27,7 +27,7 @@ region=$(jq -r '.source.region // ""' < $payload)
 role_arn=$(jq -r '.source.role_arn // ""' < $payload)
 env_var_overrides=$(jq -r '.params.env_var_overrides // []' < $payload)
 source_version=$(jq -r '.params.source_version // ""' < $payload)
-source_version_file=$(jq -r '.params.source_version // ""' < $payload)
+source_version_file=$(jq -r '.params.source_version_file // ""' < $payload)
 build_input_file=$(jq -r '.params.build_input_file // ""' < $payload)
 
 if [ -z "$region" ]; then


### PR DESCRIPTION
This is a 5 character change to have the source_version_file parameter reference the correct param supplied by the put config.