### PR TITLE
output results of check to stdout

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -39,4 +39,4 @@ fi
     set -f
     aws codebuild list-builds-for-project --project-name "$project" --query 'ids[*]' --output json
     set +f
-} | jq ".[]" | sed "/$ref/ q" | tail -r | jq -s "map({ref: .})"
+} | jq ".[]" | sed "/$ref/ q" | tail -r | jq -s "map({ref: .})" >&3


### PR DESCRIPTION
the concourse resource_type implementation requires that you output the final result to stdout during a check process.
Failing to do so creates an 'unexpected end of json' error.  

Outputting the result to stdout fixes the error, and corrects pipelines which could not be retriggered properly.