### PR TITLE
Modernize code to match current AWS landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Make sure you have a Codebuild project already setup.
 - `project`: _Required._ The name of the codebuild project
 - `region`: _Optional_. The region the Codebuild project resides in. Defaults to the value in the worker instance metadata.
 - `role_arn`: _Optional._ The role to assume before calling the command to start aws codebuild. This is not the role that Codebuild will use when it runs. Allows cross account access to Codebuild.
+- `access_key_id`: _Optional._ The access key id to use for configuring the aws cli.
+- `secret_access_key`: _Optional._ The secret access key to use for configuring the aws cli.
 
 ```
 resources:

--- a/assets/check
+++ b/assets/check
@@ -18,10 +18,20 @@ cat > $payload <&0
 project=$(jq -r '.source.project // ""' < $payload)
 role_arn=$(jq -r '.source.role_arn // ""' < $payload)
 region=$(jq -r '.source.region // ""' < $payload)
+access_key_id=$(jq -r '.source.access_key_id // ""' < $payload)
+secret_access_key=$(jq -r '.source.secret_access_key // ""' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 
 if [ -z "$region" ]; then
-    region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+  region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+fi
+
+if [ -n "$access_key_id" ]; then
+  export AWS_ACCESS_KEY_ID=$access_key_id
+fi
+
+if [ -n "$secret_access_key" ]; then
+  export AWS_SECRET_ACCESS_KEY=$secret_access_key
 fi
 
 export AWS_REGION=$region

--- a/assets/check
+++ b/assets/check
@@ -49,4 +49,4 @@ fi
     set -f
     aws codebuild list-builds-for-project --project-name "$project" --query 'ids[*]' --output json
     set +f
-} | jq ".[]" | sed "/$ref/ q" | tail -r | jq -s "map({ref: .})"
+} | jq ".[]" | sed "/$ref/ q" | tail -r | jq -s "map({ref: .})" >&3

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -43,7 +43,7 @@ wait_for_log_stream() {
     BUILD_STATUS=$(aws codebuild batch-get-builds --ids $WAIT_FOR_BUILD_ID --query 'builds[*].buildStatus' --output text)
 
     if [[ ! " ${NOT_ACCEPTABLE_PHASES[@]} " =~ " ${BUILD_STATUS} " ]]; then
-        echo "Log stream is available."
+        echo "Phase is $BUILD_STATUS. Log stream should be available."
         break
     fi
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -32,12 +32,15 @@ wait_for_build_to_finish() {
 }
 
 watch_build_logs() {
-
     BUILD_ID_TO_LOG=$1
     echo "fetching log group for $BUILD_ID_TO_LOG"
     LOG_GROUP=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.cloudWatchLogs.groupName' --output text)
     LOG_STREAM=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.cloudWatchLogs.streamName' --output text)
-    echo "log group for $BUILD_ID_TO_LOG is $LOG_GROUP,  Stream: $LOG_STREAM"
 
-    awslogs get $LOG_GROUP $LOG_STREAM --watch --no-group --no-stream | sed '/Phase complete: POST_BUILD/ q'
+    streamId=$(echo $BUILD_ID_TO_LOG | cut -d ":" -f 2)
+    LOG_STREAM_FULL="$LOG_STREAM/$streamId"
+
+    echo "log group for $BUILD_ID_TO_LOG is $LOG_GROUP,  Stream: $LOG_STREAM_FULL"
+
+    awslogs get $LOG_GROUP $LOG_STREAM_FULL --watch --no-group --no-stream | sed '/Phase complete: POST_BUILD/ q'
 }

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -31,6 +31,28 @@ wait_for_build_to_finish() {
     done
 }
 
+wait_for_log_stream() {
+    WAIT_FOR_BUILD_ID=$1
+    NOT_ACCEPTABLE_PHASES=("SUBMITTED" "QUEUED" "PROVISIONING" "DOWNLOAD_SOURCE")
+
+    echo "Waiting for the build $WAIT_FOR_BUILD_ID to enter a suitable phase for streaming the logs."
+
+    while :
+    do
+
+    BUILD_STATUS=$(aws codebuild batch-get-builds --ids $WAIT_FOR_BUILD_ID --query 'builds[*].buildStatus' --output text)
+
+    if [[ ! " ${NOT_ACCEPTABLE_PHASES[@]} " =~ " ${BUILD_STATUS} " ]]; then
+        echo "Log stream is available."
+        break
+    fi
+
+    echo "."
+
+    sleep 5
+    done
+}
+
 watch_build_logs() {
     BUILD_ID_TO_LOG=$1
     echo "fetching log group for $BUILD_ID_TO_LOG"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -35,8 +35,8 @@ watch_build_logs() {
 
     BUILD_ID_TO_LOG=$1
     echo "fetching log group for $BUILD_ID_TO_LOG"
-    LOG_GROUP=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.groupName' --output text)
-    LOG_STREAM=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.streamName' --output text)
+    LOG_GROUP=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.cloudWatchLogs.groupName' --output text)
+    LOG_STREAM=$(aws codebuild batch-get-builds --ids $BUILD_ID_TO_LOG --query 'builds[*].logs.cloudWatchLogs.streamName' --output text)
     echo "log group for $BUILD_ID_TO_LOG is $LOG_GROUP,  Stream: $LOG_STREAM"
 
     awslogs get $LOG_GROUP $LOG_STREAM --watch --no-group --no-stream | sed '/Phase complete: POST_BUILD/ q'

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -40,10 +40,10 @@ wait_for_log_stream() {
     while :
     do
 
-    BUILD_STATUS=$(aws codebuild batch-get-builds --ids $WAIT_FOR_BUILD_ID --query 'builds[*].buildStatus' --output text)
+    BUILD_PHASE=$(aws codebuild batch-get-builds --ids $WAIT_FOR_BUILD_ID --query 'builds[*].currentPhase' --output text)
 
-    if [[ ! " ${NOT_ACCEPTABLE_PHASES[@]} " =~ " ${BUILD_STATUS} " ]]; then
-        echo "Phase is $BUILD_STATUS. Log stream should be available."
+    if [[ ! " ${NOT_ACCEPTABLE_PHASES[@]} " =~ " ${BUILD_PHASE} " ]]; then
+        echo "Phase is $BUILD_PHASE. Log stream should be available."
         break
     fi
 

--- a/assets/in
+++ b/assets/in
@@ -25,12 +25,22 @@ cat > $payload <&0
 project=$(jq -r '.source.project // ""' < $payload)
 role_arn=$(jq -r '.source.role_arn // ""' < $payload)
 region=$(jq -r '.source.region // ""' < $payload)
+access_key_id=$(jq -r '.source.access_key_id // ""' < $payload)
+secret_access_key=$(jq -r '.source.secret_access_key // ""' < $payload)
 build_id=$(jq -r '.version.ref // "HEAD"' < $payload)
 
 download_artifacts=$(jq -r '(.params.submodules // "true")' < $payload)
 
 if [ -z "$region" ]; then
     region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+fi
+
+if [ -n "$access_key_id" ]; then
+  export AWS_ACCESS_KEY_ID=$access_key_id
+fi
+
+if [ -n "$secret_access_key" ]; then
+  export AWS_SECRET_ACCESS_KEY=$secret_access_key
 fi
 
 export AWS_REGION=$region

--- a/assets/out
+++ b/assets/out
@@ -104,8 +104,10 @@ LOG_PID=$!
 wait_for_build_to_finish "$BUILD_ID"
 echo "Build job has finished"
 
+set +e
 kill -9 $LOG_PID || true
 killall awslogs || true
+set -e
 
 BUILD_STATUS=$(aws codebuild batch-get-builds --ids $BUILD_ID --output text --region "$region" --query 'builds[0].buildStatus' --output text)
 

--- a/assets/out
+++ b/assets/out
@@ -25,13 +25,23 @@ cat > $payload <&0
 project=$(jq -r '.source.project // ""' < $payload)
 region=$(jq -r '.source.region // ""' < $payload)
 role_arn=$(jq -r '.source.role_arn // ""' < $payload)
+access_key_id=$(jq -r '.source.access_key_id // ""' < $payload)
+secret_access_key=$(jq -r '.source.secret_access_key // ""' < $payload)
 env_var_overrides=$(jq -r '.params.env_var_overrides // []' < $payload)
 source_version=$(jq -r '.params.source_version // ""' < $payload)
 source_version_file=$(jq -r '.params.source_version_file // ""' < $payload)
 build_input_file=$(jq -r '.params.build_input_file // ""' < $payload)
 
 if [ -z "$region" ]; then
-    region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+  region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+fi
+
+if [ -n "$access_key_id" ]; then
+  export AWS_ACCESS_KEY_ID=$access_key_id
+fi
+
+if [ -n "$secret_access_key" ]; then
+  export AWS_SECRET_ACCESS_KEY=$secret_access_key
 fi
 
 export AWS_REGION=$region
@@ -54,7 +64,7 @@ else
                 echo "Setting content of environment variable $key to the contents of the file $value"
                 file_contents=$(cat "${sources}/${value}")
                 env_var_overrides=$(echo $env_var_overrides | jq --arg key "$key" --arg value "$file_contents" '.[$key] = $value')
-            fi    
+            fi
         done
 
         env_var_overrides=$(echo "$env_var_overrides" | jq -s '.[] | to_entries | map( {name: .key, value: .value, type: "PLAINTEXT"})')
@@ -62,7 +72,7 @@ else
 
     # We need to create the build input file
     build_input=$(jq -n "{
-        \"projectName\": \"$project\", 
+        \"projectName\": \"$project\",
         \"environmentVariablesOverride\": $env_var_overrides
     }")
 

--- a/assets/out
+++ b/assets/out
@@ -104,10 +104,12 @@ LOG_PID=$!
 wait_for_build_to_finish "$BUILD_ID"
 echo "Build job has finished"
 
-echo "Killing the logging job with PID $LOG_PID"
+if ps -p $LOG_PID > /dev/null
+then
+  echo "Killing the logging job with PID $LOG_PID"
 
-kill -9 $LOG_PID;
-killall awslogs;
+  kill -9 $LOG_PID;
+fi
 
 BUILD_STATUS=$(aws codebuild batch-get-builds --ids $BUILD_ID --output text --region "$region" --query 'builds[0].buildStatus' --output text)
 

--- a/assets/out
+++ b/assets/out
@@ -104,12 +104,7 @@ LOG_PID=$!
 wait_for_build_to_finish "$BUILD_ID"
 echo "Build job has finished"
 
-if ps -p $LOG_PID > /dev/null
-then
-  echo "Killing the logging job with PID $LOG_PID"
-
-  kill -9 $LOG_PID;
-fi
+kill -9 $LOG_PID || true
 
 BUILD_STATUS=$(aws codebuild batch-get-builds --ids $BUILD_ID --output text --region "$region" --query 'builds[0].buildStatus' --output text)
 

--- a/assets/out
+++ b/assets/out
@@ -105,6 +105,7 @@ wait_for_build_to_finish "$BUILD_ID"
 echo "Build job has finished"
 
 kill -9 $LOG_PID || true
+killall awslogs || true
 
 BUILD_STATUS=$(aws codebuild batch-get-builds --ids $BUILD_ID --output text --region "$region" --query 'builds[0].buildStatus' --output text)
 

--- a/assets/out
+++ b/assets/out
@@ -106,8 +106,8 @@ echo "Build job has finished"
 
 echo "Killing the logging job with PID $LOG_PID"
 
-kill -9 $LOG_PID
-killall awslogs
+kill -9 $LOG_PID;
+killall awslogs;
 
 BUILD_STATUS=$(aws codebuild batch-get-builds --ids $BUILD_ID --output text --region "$region" --query 'builds[0].buildStatus' --output text)
 

--- a/assets/out
+++ b/assets/out
@@ -94,7 +94,7 @@ BUILD_ID=$(aws codebuild start-build --query 'build.id' --output text --region "
 echo "Started build $BUILD_ID"
 
 # The log group is typically not ready right away
-sleep 2
+wait_for_log_stream "$BUILD_ID"
 
 # Kick off the log streaming in the background
 watch_build_logs "$BUILD_ID" &

--- a/create_image.sh
+++ b/create_image.sh
@@ -3,7 +3,7 @@
 REPO=$1
 TAG=$2
 
-docker build --no-cache -t $REPO:latest .
+docker build -t $REPO:latest .
 docker push $REPO:latest
 docker tag $REPO:latest $REPO:$TAG
 docker push $REPO:$TAG

--- a/create_image.sh
+++ b/create_image.sh
@@ -3,7 +3,7 @@
 REPO=$1
 TAG=$2
 
-docker build -t $REPO:latest .
+docker build --no-cache -t $REPO:latest .
 docker push $REPO:latest
 docker tag $REPO:latest $REPO:$TAG
 docker push $REPO:$TAG

--- a/create_image.sh
+++ b/create_image.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+REPO=$1
+TAG=$2
+
+docker build -t $REPO:latest .
+docker push $REPO:latest
+docker tag $REPO:latest $REPO:$TAG
+docker push $REPO:$TAG


### PR DESCRIPTION
This started out by a need to supply credentials from the outside and quickly evolved to:
* add `access_key_id` and `secret_access_key` arguments to supply credentials
* use the correct log stream name (b8c3dab)
* wait until an acceptable build phase was entered to overcome the provisioning phases where no log group is present